### PR TITLE
cronfile: Suppress all output on rebuild

### DIFF
--- a/cronfile.txt
+++ b/cronfile.txt
@@ -16,6 +16,6 @@ SHELL=/bin/bash
 ### PLACE ALL CRON TASKS BELOW
 
 # restart the application in the morning to load the new data
-0 6 * * * dokku dokku ps:rebuild col > /dev/null
+0 6 * * * dokku dokku ps:rebuild col &> /dev/null
 
 ### PLACE ALL CRON TASKS ABOVE, DO NOT REMOVE THE WHITESPACE AFTER THIS LINE


### PR DESCRIPTION
We're seeing a warning on the cron job that we don't need to care about. "
! Detected IPv4 domain name with nginx proxy enabled. ! Ensure the default nginx site is removed before continuing. "